### PR TITLE
[WIP] address PEARLS-418 #53 

### DIFF
--- a/prism/data/repair/instance.py
+++ b/prism/data/repair/instance.py
@@ -135,7 +135,6 @@ class LocDiff:
             b.beg_charno - a.beg_charno,
             b.end_charno - a.end_charno)
 
-
 @dataclass
 class VernacCommandDataListDiff:
     """
@@ -1776,6 +1775,9 @@ class ProjectCommitDataErrorInstance(ErrorInstance[ProjectCommitData,
             new_location = repaired_command.spanning_location()
             broken_command.command.location = broken_command.location.rename(
                 repair_filename)
+            for proof in broken_command.proofs:
+                for s in proof:
+                    s.location = s.location.rename(repair_filename)
             (num_excess_lines,
              num_excess_chars) = broken_command.relocate(new_location)
             # recreate diff


### PR DESCRIPTION
Proof lines were not being relocated with their associated statements.

This change made the offending commits in #53 produce output. 

This should be considered a WIP pull because a new error was noted in the logs after this change was made-- it might be that this caused an error, or that this patched something else which allowed another error to be expressed.

