### PR TITLE
Dirtyflag for finding corrupt switches.

### DIFF
--- a/prism/util/opam/switch.py
+++ b/prism/util/opam/switch.py
@@ -102,6 +102,9 @@ class OpamSwitch:
         object.__setattr__(self, 'name', switch_name)
         object.__setattr__(self, 'root', switch_root)
         object.__setattr__(self, '_is_external', self.is_external(self.name))
+        if (self.path / ".dirtyflag").exists():
+            raise InterruptedError("Switch exists, but is dirty \
+                and cannot be used.")
         # force computation of environment to validate switch exists
         self.env
 

--- a/prism/util/opam/switch.py
+++ b/prism/util/opam/switch.py
@@ -103,7 +103,8 @@ class OpamSwitch:
         object.__setattr__(self, 'root', switch_root)
         object.__setattr__(self, '_is_external', self.is_external(self.name))
         if (self.path / ".dirtyflag").exists():
-            raise InterruptedError("Switch exists, but is dirty \
+            raise InterruptedError(
+                "Switch exists, but is dirty \
                 and cannot be used.")
         # force computation of environment to validate switch exists
         self.env

--- a/prism/util/swim/auto.py
+++ b/prism/util/swim/auto.py
@@ -2,8 +2,8 @@
 Defines an adaptive switch manager that initializes itself.
 """
 
-from pathlib import Path
 import shutil
+from pathlib import Path
 from typing import Iterable, List, Optional
 
 from prism.util.opam import AssignedVariables, OpamSwitch

--- a/prism/util/swim/auto.py
+++ b/prism/util/swim/auto.py
@@ -3,6 +3,7 @@ Defines an adaptive switch manager that initializes itself.
 """
 
 from pathlib import Path
+import shutil
 from typing import Iterable, List, Optional
 
 from prism.util.opam import AssignedVariables, OpamSwitch
@@ -74,6 +75,13 @@ class AutoSwitchManager(AdaptiveSwitchManager):
                     switch = OpamSwitch(potential_switch.name, root)
                 except ValueError:
                     continue
+                except InterruptedError:
+                    # this switch is dirty.
+                    # since this ought to be the only switch manager
+                    # running at the moment, it must have been
+                    # an interrupted copy.
+                    # deleting it.
+                    shutil.rmtree(potential_switch)
                 else:
                     switches.append(switch)
         return switches


### PR DESCRIPTION
Opam itself implements decent locking-- I've never managed to create a broken switch by interrupting it and it catches ctrl-c's and shuts down quickly but gracefully.

This leaves our clone creation and deletion as routines that can corrupt switches if they are interrupted.

Clone creation places a dirtyflag which prevents the switch from being used and causes the broken switch to be deleted when autoswitchmanager finds it.

Since `shutil.rmtree` doesn't have an ignore argument and it's probably not a safe idea to reimplement safe symlink logic, we can't use the dirtyflag-- it might get deleted first without reimplementing a portion of rmtree's logic. Instead, we just delete the switch's environment file first. Switch deletion is much faster than switch creation, so it is much less likely to be interrupted, but if it is, then the partially deleted switch will not have an environment file, which causes autoswitchmanager to fail to recognize it as a switch during enumeration and ignore it.

These changes passed the existing test cases. I also manually tested that the dirtyflag switches are deleted on startup (`watch "find -maxdepth 2 ~/.opam | grep dirtyflag"` or similar) and watched dirtyflags get added and deleted in the course of extraction mining. I did no manual testing of the deletion logic, but it ran successfully during tests. All it does is delete a file first, so if the file it deleted didn't exist it would have thrown an error in the course of testing.